### PR TITLE
修复选择应用搜索多次按下回车后崩溃、支持回车搜索；列表性能优化

### DIFF
--- a/app/src/main/java/com/tumuyan/fixedplay/App/ItemAdapter.java
+++ b/app/src/main/java/com/tumuyan/fixedplay/App/ItemAdapter.java
@@ -1,11 +1,12 @@
 
 package com.tumuyan.fixedplay.App;
+
+import static android.content.Context.MODE_MULTI_PROCESS;
+
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
-//import android.database.sqlite.SQLiteDatabase;
-//import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -18,8 +19,6 @@ import com.tumuyan.fixedplay.R;
 import com.tumuyan.fixedplay.SettingActivity;
 
 import java.util.List;
-
-import static android.content.Context.MODE_MULTI_PROCESS;
 
 
 /**
@@ -46,11 +45,27 @@ public class ItemAdapter extends ArrayAdapter<Item> {
         this.uri = uri;
     }
 
+    private static class ViewHolder {
+        public ViewHolder(View viewRoot) {
+            item_img = (ImageView) viewRoot.findViewById(R.id.item_img);
+            item_text = (TextView) viewRoot.findViewById(R.id.item_text);
+            item_packageName = (TextView) viewRoot.findViewById(R.id.item_packageName);
+        }
+
+        ImageView item_img;
+        TextView item_text;
+        TextView item_packageName;
+    }
+
   //  @NonNull
     @Override
     public View getView(final int position, View convertView, final ViewGroup parent) {
         final Item item = getItem(position);
-        View view = LayoutInflater.from(getContext()).inflate(layoutId, parent, false);
+        if (convertView == null) {
+            convertView = LayoutInflater.from(getContext()).inflate(layoutId, parent, false);
+            ViewHolder holder = new ViewHolder(convertView);
+            convertView.setTag(holder);
+        }
         final String packageName = item.getPackageName();
         final String className = item.getClassName();
         final String Name = item.getName();
@@ -68,16 +83,18 @@ public class ItemAdapter extends ArrayAdapter<Item> {
             _package = packageName + "\n" + className;
         }
 
-        ((ImageView) view.findViewById(R.id.item_img)).setImageDrawable(item.getAppIcon());
-        ((TextView) view.findViewById(R.id.item_text)).setText(_name);
-        ((TextView)view.findViewById(R.id.item_packageName)).setText(_package);
-        view.setOnClickListener(new View.OnClickListener() {
+        ViewHolder holder = (ViewHolder) convertView.getTag();
+        holder.item_img.setImageDrawable(null);
+        holder.item_img.setImageDrawable(item.getAppIcon());
+        holder.item_text.setText(_name);
+        holder.item_packageName.setText(_package);
+        convertView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 select(Name,packageName,className);
             }
         });
-        return view;
+        return convertView;
     }
 
 

--- a/app/src/main/java/com/tumuyan/fixedplay/App/SelectOne.java
+++ b/app/src/main/java/com/tumuyan/fixedplay/App/SelectOne.java
@@ -1,32 +1,21 @@
 package com.tumuyan.fixedplay.App;
 
 import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
-
-import android.text.Editable;
-import android.text.TextWatcher;
 import android.util.Log;
-import android.view.Gravity;
 import android.view.KeyEvent;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
-import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.ProgressBar;
-import android.widget.Toast;
 
-import com.tumuyan.fixedplay.MainActivity;
 import com.tumuyan.fixedplay.R;
 
 import java.io.File;
@@ -96,6 +85,7 @@ public class SelectOne extends Activity {
 
                                         int selectedItemPosition = listView.getSelectedItemPosition();
                                         Log.i("App SelectorOne", "Keycode = " + keyCode + ", cursorPosition = " + selectedItemPosition);
+                                        if (selectedItemPosition < 0) return false;
                                         Item item = list.get(selectedItemPosition);
                                         itemAdapter.select(item.getName(), item.getPackageName(), item.getClassName() );
                                         return true;
@@ -117,6 +107,19 @@ public class SelectOne extends Activity {
             @Override
             public void onClick(View view) {
                 doSearch(SearchText.getText().toString());
+            }
+        });
+
+        SearchText.setOnKeyListener(new View.OnKeyListener() {
+            @Override
+            public boolean onKey(View v, int keyCode, KeyEvent event) {
+                if (event.getAction() == KeyEvent.ACTION_UP) {
+                    if (keyCode == KeyEvent.KEYCODE_ENTER || keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER) {
+                        doSearch(SearchText.getText().toString());
+                        return true;
+                    }
+                }
+                return false;
             }
         });
     }

--- a/app/src/main/java/com/tumuyan/fixedplay/App/SelectOne.java
+++ b/app/src/main/java/com/tumuyan/fixedplay/App/SelectOne.java
@@ -114,7 +114,7 @@ public class SelectOne extends Activity {
             @Override
             public boolean onKey(View v, int keyCode, KeyEvent event) {
                 if (event.getAction() == KeyEvent.ACTION_UP) {
-                    if (keyCode == KeyEvent.KEYCODE_ENTER || keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER) {
+                    if (keyCode == KeyEvent.KEYCODE_ENTER || keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER || keyCode == KeyEvent.KEYCODE_DPAD_CENTER) {
                         doSearch(SearchText.getText().toString());
                         return true;
                     }

--- a/app/src/main/res/layout/applist_activity.xml
+++ b/app/src/main/res/layout/applist_activity.xml
@@ -31,7 +31,8 @@
             android:layout_weight="1"
             android:ems="10"
             android:hint="App label/Package/Activity."
-            android:inputType="textPersonName" />
+            android:inputType="textPersonName"
+            android:imeOptions="actionSearch" />
 
 
         <Button


### PR DESCRIPTION
1. 错误原因：回车后焦点位于ListView，再回车后事件被ListView接收，此时选择的item位置为-1，调用get报越界错误；在get前做了判断。
2. 通过EditText的imeOptions，将事件设置为搜索，并添加了回车监听。
3. ItemAdapter性能优化：添加convertedView复用、ViewHolder缓存。